### PR TITLE
Element API for Craft CMS link

### DIFF
--- a/pages/code.markdown
+++ b/pages/code.markdown
@@ -8,5 +8,6 @@
 * [JSON Feed for Jekyll](https://github.com/vallieres/jekyll-json-feed) by Alexandre Vallières-Lagacé
 * [Jekyll feed with attachments](https://github.com/tedchoward/tidbits/blob/master/feed.json) by Ted Howard
 * [Movable Type template and EscapeForJSON](https://daringfireball.net/projects/mt-escapeforjson/) by John Gruber
+* [Element API for Craft CMS](https://github.com/craftcms/element-api/tree/v1) by Pixel & Tonic
 
 As more code is published, by us and others, we’ll add to this page.


### PR DESCRIPTION
Element API is a first-party Craft CMS plugin for creating JSON APIs. v1.4 added support for creating JSON feeds.