### PR TITLE
Suggest alternate media type.

### DIFF
--- a/pages/version/1.markdown
+++ b/pages/version/1.markdown
@@ -175,7 +175,7 @@ In future versions, defined keys will always adhere to these rules:
 
 ## Suggestions for Publishers
 
-JSON Feed files must be served using the same MIME type — `application/json` — that’s used whenever JSON is served.
+JSON Feed files should be served with the Internet Media Type `application/feed+json`, following the guidance in [RFC6839](https://tools.ietf.org/html/rfc6839).
 
 The number of items in a feed is unlimited, but practical limits should be observed. A 1MB feed places a burden on feed readers, especially if there are many such feeds. Under 100K is ideal, and 250K is fine. Use your judgment. If you need to provide older items, consider using pagination and `next_url`.
 


### PR DESCRIPTION
Why shouldn't this thing have its own media type?  If you're sticking it in your HTML header with 

<link rel='alternate' type='application/json'

Then it's going to make it harder to discover the feed, because you might have multiple alternate JSON representations, things like Rails make it super easy to get either HTML or JSON from the same endpoint.

I look in my current blog header and see

<link rel='alternate' type='application/atom+xml'

So by analogy, I think application/feed+json would be better. It makes it dead easy for Feedly or whatever to figure out what to do, given the URL of my blog.  If you want to do this, I'll even volunteer to register the media type, it's not rocket science.

