### PR TITLE
Clarify `attachments` being an array of objects

### DIFF
--- a/pages/version/1.markdown
+++ b/pages/version/1.markdown
@@ -119,7 +119,7 @@ After that there’s an array of objects — `items` — that describe each obj
 
 An individual item may have one or more attachments.
 
-* `attachments` (optional, array) lists related resources. Podcasts, for instance, would include an attachment that’s an audio or video file. Each attachment has several members:
+* `attachments` (optional, array of objects) lists related resources. Podcasts, for instance, would include an attachment that’s an audio or video file. Each attachment has several members:
 
     * `url` (required, string) specifies the location of the attachment.
 


### PR DESCRIPTION
Both `hubs` and `tags` state which type of elements they contain:

> `hubs` (very optional, array of objects) …

> `tags` (optional, array of strings) …

Therefore, I have clarified the type of elements `attachments` contains.