### PR TITLE
Add JsonFeed.NET library to the Code page

### DIFF
--- a/pages/code.markdown
+++ b/pages/code.markdown
@@ -22,5 +22,6 @@
 * [Pelican plugin](https://github.com/andrewheiss/pelican_json_feed) by Andrew Heiss
 * [Pelican feed template](https://github.com/andrewheiss/athpelican/blob/master/theme/templates/feed.json) by Andrew Heiss
 * [C# parsing library](https://github.com/gramgibson/jsonfeed) by Gram Gibson
+* [C# parsing & generator library](https://github.com/DanRigby/JsonFeed.NET) by Dan Rigby
 
 As more code is published, by us and others, we’ll add to this page.


### PR DESCRIPTION
JsonFeed.NET is a portable .NET library for generating and consuming JSON Feed compliant site feeds.

#### Supported platforms

* .NET Framework 4.5.1+
* .NET Core 1.1+
* Mono
* UWP
* Xamarin.iOS
* Xamarin.Android