### PR TITLE
link to Perl5 JSON::Feed module.

### DIFF
--- a/pages/code.markdown
+++ b/pages/code.markdown
@@ -29,5 +29,6 @@
 * [Scala parser & generator library](https://github.com/chobeat/scala-json-feed) by Simone Robutti
 * [Java parsing library](https://github.com/devilgate/pertwee) by Martin McCallion
 * [JS JSON Feed to Atom converter](https://github.com/bcomnes/jsonfeed-to-atom) by Bret Comnes
+* [Perl5 JSON::Feed parser and generator](https://metacpan.org/pod/JSON::Feed) by Kang-min Liu
 
 As more code is published, by us and others, we’ll add to this page.


### PR DESCRIPTION
Hi, 

I made the a model class JSON::Feed for Perl5 which can be use for both parsing and generation. I though it would be nice if the module can be enlisted in the "Code" page: https://jsonfeed.org/code

I'm not sure if this PR alone is sufficient, but it appears that `code.markdown` maps this webpage.

If not,  the module documentation (and other details) are linked from https://metacpan.org/pod/JSON::Feed, while its repository is located: https://github.com/gugod/JSON-Feed

Thanks for spec out JSON Feed. 👍 
