### PR TITLE
Add Rust crate json-feed-model

### DIFF
--- a/pages/code.markdown
+++ b/pages/code.markdown
@@ -13,6 +13,7 @@
 * [Movable Type template and EscapeForJSON](https://daringfireball.net/projects/mt-escapeforjson/) by John Gruber
 * [Craft CMS with Element API](https://github.com/craftcms/element-api/tree/v1#json-feed) by Pixel & Tonic
 * [Rust crate](https://crates.io/crates/jsonfeed) by Paul Woolcock
+* [Rust crate](https://crates.io/crates/json-feed-model) by Bryant Luk
 * [Hugo feed template](https://gist.github.com/voidfiles/302e8d690a5ef4990e371ce70bca3240) by Alex Kessinger
 * [Hugo feed template](https://github.com/frjo/hugo-theme-zen/blob/master/layouts/_default/list.json.json) by Fredrik Jonsson
 * [Python feed validator](https://github.com/voidfiles/jsonfeedvalidator) by Alex Kessinger


### PR DESCRIPTION
Add a link to a new Rust crate: https://crates.io/crates/json-feed-model .

Source is at https://github.com/bluk/json-feed-model .